### PR TITLE
Django 1.11 tests compatibility

### DIFF
--- a/impersonate/templates/impersonate/list_users.html
+++ b/impersonate/templates/impersonate/list_users.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <html>
 <head>
   <title>Django Impersonate User List</title>

--- a/impersonate/templates/impersonate/search_users.html
+++ b/impersonate/templates/impersonate/search_users.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <html>
 <head>
   <title>Django Impersonate - Search Users</title>

--- a/runtests.py
+++ b/runtests.py
@@ -1,6 +1,7 @@
 import sys
 
 import django
+import os
 from django.conf import settings
 from django.test.utils import get_runner
 
@@ -27,6 +28,23 @@ settings.configure(
         'django.contrib.admin',
         APP_NAME,
     ),
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [
+                os.path.join(APP_NAME, 'templates'),
+            ],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.request',
+                    'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages',
+                ],
+            },
+        },
+    ]
 )
 
 


### PR DESCRIPTION
Fix for unit tests to be runned on:
Python 3.4.0
Django 1.11.16

The modifications are necessary to prove that tests work on the new environment.